### PR TITLE
JPA Auditing 활용하여 생성 및 수정시간 자동화

### DIFF
--- a/src/main/java/org/yunho/pharmacyrecommendation/BaseTimeEntity.java
+++ b/src/main/java/org/yunho/pharmacyrecommendation/BaseTimeEntity.java
@@ -1,0 +1,24 @@
+package org.yunho.pharmacyrecommendation;
+
+import jakarta.persistence.Column;
+import jakarta.persistence.EntityListeners;
+import jakarta.persistence.MappedSuperclass;
+import lombok.Getter;
+import org.springframework.data.annotation.CreatedDate;
+import org.springframework.data.annotation.LastModifiedDate;
+import org.springframework.data.jpa.domain.support.AuditingEntityListener;
+
+import java.time.LocalDateTime;
+
+@Getter
+@MappedSuperclass
+@EntityListeners(AuditingEntityListener.class)
+public abstract class BaseTimeEntity {
+
+    @CreatedDate
+    @Column(updatable = false)
+    private LocalDateTime createdDate;
+
+    @LastModifiedDate
+    private LocalDateTime modifiedDate;
+}

--- a/src/main/java/org/yunho/pharmacyrecommendation/PharmacyRecommendationApplication.java
+++ b/src/main/java/org/yunho/pharmacyrecommendation/PharmacyRecommendationApplication.java
@@ -2,7 +2,9 @@ package org.yunho.pharmacyrecommendation;
 
 import org.springframework.boot.SpringApplication;
 import org.springframework.boot.autoconfigure.SpringBootApplication;
+import org.springframework.data.jpa.repository.config.EnableJpaAuditing;
 
+@EnableJpaAuditing
 @SpringBootApplication
 public class PharmacyRecommendationApplication {
 

--- a/src/main/java/org/yunho/pharmacyrecommendation/pharmacy/entity/Pharmacy.java
+++ b/src/main/java/org/yunho/pharmacyrecommendation/pharmacy/entity/Pharmacy.java
@@ -8,13 +8,14 @@ import lombok.AllArgsConstructor;
 import lombok.Builder;
 import lombok.Getter;
 import lombok.NoArgsConstructor;
+import org.yunho.pharmacyrecommendation.BaseTimeEntity;
 
 @Entity(name = "pharmacy")
 @Getter
 @Builder
 @NoArgsConstructor
 @AllArgsConstructor
-public class Pharmacy {
+public class Pharmacy extends BaseTimeEntity {
 
     @Id
     @GeneratedValue(strategy = GenerationType.IDENTITY)

--- a/src/test/java/org/yunho/pharmacyrecommendation/pharmacy/repository/PharmacyRepositoryTest.java
+++ b/src/test/java/org/yunho/pharmacyrecommendation/pharmacy/repository/PharmacyRepositoryTest.java
@@ -7,9 +7,12 @@ import org.springframework.boot.test.context.SpringBootTest;
 import org.yunho.pharmacyrecommendation.AbstractIntegrationContainerBaseTest;
 import org.yunho.pharmacyrecommendation.pharmacy.entity.Pharmacy;
 
+import java.time.LocalDateTime;
 import java.util.Collections;
+import java.util.List;
 
 import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertTrue;
 
 @SpringBootTest
 public class PharmacyRepositoryTest extends AbstractIntegrationContainerBaseTest {
@@ -69,5 +72,27 @@ public class PharmacyRepositoryTest extends AbstractIntegrationContainerBaseTest
         // then
         long count = result.spliterator().getExactSizeIfKnown(); // Count number of items
         assertEquals(1, count);
+    }
+
+    @Test
+    void givenPharmacy_whenSaved_thenCreatedAndModifiedDatesShouldBeSet() {
+        // Given
+        LocalDateTime now = LocalDateTime.now();
+        String address = "서울 특별시 성북구 종암동";
+        String name = "은혜 약국";
+
+        Pharmacy pharmacy = Pharmacy.builder()
+                .pharmacyAddress(address)
+                .pharmacyName(name)
+                .build();
+
+        // When
+        pharmacyRepository.save(pharmacy);
+        List<Pharmacy> result = pharmacyRepository.findAll();
+
+        // Then
+        Pharmacy savedPharmacy = result.get(0);
+        assertTrue(savedPharmacy.getCreatedDate().isAfter(now));
+        assertTrue(savedPharmacy.getModifiedDate().isAfter(now));
     }
 }


### PR DESCRIPTION
이 pr은 약국 엔티티에 생성 및 수정시간 추가함

This closes #7 